### PR TITLE
Cherry-picks and changes from "irobot/iron" for Jazzy

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -330,6 +330,11 @@ RMW_INTERFACE_FN(
   2, ARG_TYPES(const rmw_publisher_t *, size_t *))
 
 RMW_INTERFACE_FN(
+  rmw_publisher_count_non_local_matched_subscriptions,
+  rmw_ret_t, RMW_RET_ERROR,
+  2, ARG_TYPES(const rmw_publisher_t *, size_t *))
+
+RMW_INTERFACE_FN(
   rmw_publisher_get_actual_qos,
   rmw_ret_t, RMW_RET_ERROR,
   2, ARG_TYPES(const rmw_publisher_t *, rmw_qos_profile_t *))
@@ -814,6 +819,7 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_publish)
   GET_SYMBOL(rmw_publish_loaned_message)
   GET_SYMBOL(rmw_publisher_count_matched_subscriptions)
+  GET_SYMBOL(rmw_publisher_count_non_local_matched_subscriptions)
   GET_SYMBOL(rmw_publisher_get_actual_qos)
   GET_SYMBOL(rmw_publisher_event_init)
   GET_SYMBOL(rmw_publish_serialized_message)
@@ -934,6 +940,7 @@ unload_library()
   symbol_rmw_publish = nullptr;
   symbol_rmw_publish_loaned_message = nullptr;
   symbol_rmw_publisher_count_matched_subscriptions = nullptr;
+  symbol_rmw_publisher_count_non_local_matched_subscriptions = nullptr;
   symbol_rmw_publisher_get_actual_qos = nullptr;
   symbol_rmw_publisher_event_init = nullptr;
   symbol_rmw_publish_serialized_message = nullptr;


### PR DESCRIPTION
Refs #18846: PoC ignore local endpoints: export and load RMW symbols
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>
(cherry picked from commit c7e208b4fd0c456eb3eea561734f5126951ad2f1)